### PR TITLE
Develop

### DIFF
--- a/src/common/dtos/userid-query.dto.ts
+++ b/src/common/dtos/userid-query.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsMongoId } from 'class-validator';
+
+export class UserIDQueryDTO {
+  @ApiProperty({ required: true, description: 'Envie um id válido do mongoDB' })
+  @IsString({ message: 'O ID deve ser uma string.' })
+  @IsNotEmpty({ message: 'O ID não pode estar vazio.' })
+  @IsMongoId({ message: 'O ID fornecido não está em um formato válido.' })
+  user_id: string;
+}

--- a/src/common/dtos/username-query.dto.ts
+++ b/src/common/dtos/username-query.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class UsernameQueryDTO {
+  @ApiProperty({ required: true, description: 'Envie um username válido' })
+  @IsString({ message: 'O username deve ser uma string.' })
+  @IsNotEmpty({ message: 'O username não pode estar vazio.' })
+  username: string;
+}

--- a/src/discover/controllers/discover.controller.ts
+++ b/src/discover/controllers/discover.controller.ts
@@ -1,10 +1,5 @@
 import { Controller, Get, Query, Param } from '@nestjs/common';
-import {
-  ApiBearerAuth,
-  ApiOperation,
-  ApiResponse,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { IDQueryDTO } from '../../common/dtos/id-query.dto';
 import { VideoResponseDto } from '../../videos/dto/response-video.dto';
 import { DiscoverService } from '../services/discover.service';
@@ -14,7 +9,6 @@ import { PaginatedResponseVideosDto } from '../../videos/dto/paginated-response-
 import { VideoQueryDto } from '../dto/video-query.dto';
 import { UserIDQueryDTO } from '../../common/dtos/userid-query.dto';
 
-@ApiBearerAuth()
 @ApiTags('Discover')
 @Controller('/discover')
 export class DiscoverController {

--- a/src/discover/controllers/discover.controller.ts
+++ b/src/discover/controllers/discover.controller.ts
@@ -1,0 +1,65 @@
+import { Controller, Get, Query, Param } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { IDQueryDTO } from '../../common/dtos/id-query.dto';
+import { VideoResponseDto } from '../../videos/dto/response-video.dto';
+import { DiscoverService } from '../services/discover.service';
+import { UsernameQueryDTO } from '../../common/dtos/username-query.dto';
+import { UserResponseDto } from '../../users/dto/user-response.dto';
+import { PaginatedResponseVideosDto } from '../../videos/dto/paginated-response-video.dto';
+import { VideoQueryDto } from '../dto/video-query.dto';
+import { UserIDQueryDTO } from '../../common/dtos/userid-query.dto';
+
+@ApiBearerAuth()
+@ApiTags('Discover')
+@Controller('/discover')
+export class DiscoverController {
+  constructor(private readonly discoverService: DiscoverService) {}
+
+  @ApiOperation({ summary: 'Obter video de um usuário' })
+  @ApiResponse({
+    status: 200,
+    description: 'Video do usuário retornado com sucesso',
+    type: VideoResponseDto,
+  })
+  @Get('videos/:id')
+  discoverPublicVideosByID(
+    @Param() params: IDQueryDTO,
+  ): Promise<VideoResponseDto> {
+    return this.discoverService.findOne(params.id);
+  }
+
+  @ApiOperation({ summary: 'Descobrir usuários na plataforma' })
+  @ApiResponse({
+    status: 200,
+    description: 'Listagem de usuários retornada com sucesso',
+    type: UserResponseDto,
+  })
+  @Get('users/:username')
+  discoverPublicUsers(
+    @Param() params: UsernameQueryDTO,
+  ): Promise<UserResponseDto> {
+    return this.discoverService.discoverPublicUsersByUsername(params.username);
+  }
+
+  @ApiOperation({ summary: 'Descobrir videos na plataforma.' })
+  @ApiResponse({
+    status: 200,
+    description: 'Listagem de videos retornada com sucesso',
+    type: PaginatedResponseVideosDto,
+  })
+  @Get('videos/users/:user_id')
+  discoverPublicVideosByUserId(
+    @Param() params: UserIDQueryDTO,
+    @Query() query: VideoQueryDto,
+  ): Promise<PaginatedResponseVideosDto> {
+    return this.discoverService.discoverPublicVideosByUserId(
+      params.user_id,
+      query,
+    );
+  }
+}

--- a/src/discover/discover.module.ts
+++ b/src/discover/discover.module.ts
@@ -4,6 +4,8 @@ import { Video, VideoSchema } from '../videos/entities/video.entity';
 import { User, UserSchema } from '../users/schemas/user.entity';
 import { UserDiscoverController } from './controllers/user-discover.controller';
 import { UserDiscoverService } from './services/user-discover.service';
+import { DiscoverController } from './controllers/discover.controller';
+import { DiscoverService } from './services/discover.service';
 
 @Module({
   imports: [
@@ -12,7 +14,7 @@ import { UserDiscoverService } from './services/user-discover.service';
       { name: User.name, schema: UserSchema },
     ]),
   ],
-  controllers: [UserDiscoverController],
-  providers: [UserDiscoverService],
+  controllers: [UserDiscoverController, DiscoverController],
+  providers: [UserDiscoverService, DiscoverService],
 })
 export class DiscoverModule {}

--- a/src/discover/dto/video-query.dto.ts
+++ b/src/discover/dto/video-query.dto.ts
@@ -1,7 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { PaginationQueryDto } from '../../common/dtos/pagination-query.dto';
 import VideoPlatform from '../../videos/enums/video-type.enum';
-import { IsEnum, IsOptional } from 'class-validator';
+import {
+  IsEnum,
+  IsMongoId,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class VideoQueryDto extends PaginationQueryDto {
   @ApiProperty({ required: false })
@@ -18,4 +24,12 @@ export class TitleVideoQueryDto {
   @ApiProperty({ required: false })
   @IsOptional()
   title?: string;
+}
+
+export class UserVideoQuetyDto extends PaginationQueryDto {
+  @ApiProperty({ required: true, description: 'Envie um id válido do mongoDB' })
+  @IsString({ message: 'O ID deve ser uma string.' })
+  @IsNotEmpty({ message: 'O ID não pode estar vazio.' })
+  @IsMongoId({ message: 'O ID fornecido não está em um formato válido.' })
+  user_id: string;
 }

--- a/src/discover/services/discover.service.ts
+++ b/src/discover/services/discover.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { VideoQueryDto } from '../dto/video-query.dto';
+import { PaginatedResponseVideosDto } from '../../videos/dto/paginated-response-video.dto';
+import { VideoResponseDto } from '../../videos/dto/response-video.dto';
+import { PaginationService } from '../../common/services/pagination.service';
+import { Video, VideoDocument } from '../../videos/entities/video.entity';
+import { Model } from 'mongoose';
+import { InjectModel } from '@nestjs/mongoose';
+import { User, UserDocument } from '../../users/schemas/user.entity';
+import { UserResponseDto } from '../../users/dto/user-response.dto';
+
+@Injectable()
+export class DiscoverService {
+  constructor(
+    @InjectModel(Video.name)
+    private videoModel: Model<VideoDocument>,
+
+    @InjectModel(User.name)
+    private userModel: Model<UserDocument>,
+
+    private readonly paginationService: PaginationService,
+  ) {}
+
+  private async findVideoByID(_id: string): Promise<Video> {
+    const video = await this.videoModel.findOne({ privy: false, _id });
+
+    if (!video) throw new NotFoundException('Vídeo não encontrado.');
+
+    return video;
+  }
+
+  public async findOne(_id: string): Promise<VideoResponseDto> {
+    const video = await this.findVideoByID(_id);
+    return new VideoResponseDto(video);
+  }
+
+  private async findUserByUsername(username: string): Promise<User> {
+    const user = await this.userModel.findOne({ privy: false, username });
+
+    if (!user) throw new NotFoundException('User not found');
+
+    return user;
+  }
+
+  public async discoverPublicUsersByUsername(
+    username: string,
+  ): Promise<UserResponseDto> {
+    const user = await this.findUserByUsername(username);
+    return new UserResponseDto(user);
+  }
+
+  public async discoverPublicVideosByUserId(
+    user_id: string,
+    query: VideoQueryDto,
+  ): Promise<PaginatedResponseVideosDto> {
+    const filters: any = { user_id };
+
+    if (query.platform) filters.platform = query.platform;
+
+    if (query.title) {
+      filters.title = {
+        $regex: `.*${query.title.toLowerCase()}.*`,
+        $options: 'i',
+      };
+    }
+
+    const paginatedData = await this.paginationService.pagination(
+      this.videoModel,
+      query.page,
+      filters,
+    );
+
+    const data = paginatedData.data.map((video) => new VideoResponseDto(video));
+
+    return new PaginatedResponseVideosDto(data, paginatedData.meta);
+  }
+}


### PR DESCRIPTION
# Description 

Display public profile by username (with token and without token) I think the vizu is different with and without the token or the same vizu? If it's the same vizu, just one route (It would be the route to bring the profile data and the route to bring the public videos)

Fixes # (issue)

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
